### PR TITLE
Fix spelling and grammar errors across translation files

### DIFF
--- a/frontend/src/components/pages/structure-home/home-en.html
+++ b/frontend/src/components/pages/structure-home/home-en.html
@@ -79,7 +79,7 @@
         </tr>
         <tr>
             <td>
-                If your project is founded by institutional donors and you need to track other
+                If your project is funded by institutional donors and you need to track other
                 <a
                     class="btn btn-default btn-xs"
                     ui-sref="project.config.logical_frame_list"
@@ -124,7 +124,7 @@
                     <span translate="project.collection_form_list"></span>
                 </a>
 
-                from which you plan to extract the data that will be necesary to compute your
+                from which you plan to extract the data that will be necessary to compute your
                 indicators.<br />
                 As you progress, update the formulas for calculating your indicators in
                 <a

--- a/frontend/src/components/pages/structure-home/home-es.html
+++ b/frontend/src/components/pages/structure-home/home-es.html
@@ -1,6 +1,6 @@
 <div class="project-content-inner">
     <p>
-        Esta sección le ayudará a formalizar su proyecto. Debe ser utilizado durante la fase de
+        Esta sección le ayudará a formalizar su proyecto. Debe ser utilizada durante la fase de
         planificación del proyecto y revisada durante la fase de implementación del proyecto.
     </p>
     <p>
@@ -17,7 +17,7 @@
         <li>
             Enumere sus herramientas de recolección de datos (Excel, papel, ...) así como otras
             fuentes de datos (SNIS, encuestas ...) que usará para calcular sus indicadores,
-            informando sus sitios de periodicidad y recolección y sus contenido
+            informando su periodicidad, sitios de recolección y su contenido
         </li>
     </ul>
 </div>
@@ -78,7 +78,7 @@
         </tr>
         <tr>
             <td>
-                Si su proyecto esta financiado por fondos institucionales y que otros
+                Si su proyecto está financiado por fondos institucionales y otros
                 <a
                     class="btn btn-default btn-xs"
                     ui-sref="project.config.logical_frame_list"
@@ -87,7 +87,7 @@
                     <i class="fa fa-sign-out"></i>
                     <span translate="shared.logical_frames"></span>
                 </a>
-                seran usados en el mismo proyecto, agréguelos los tambien.
+                serán usados en el mismo proyecto, agréguelos también.
             </td>
             <td>
                 <progress-bar done="$ctrl.percentages.otherLfDone"></progress-bar>

--- a/frontend/src/components/pages/structure-home/home-fr.html
+++ b/frontend/src/components/pages/structure-home/home-fr.html
@@ -1,6 +1,6 @@
 <div class="project-content-inner">
     <p>
-        Cette section va vous aider à formaliser votre projet. Elle doit être utilisé pendant la
+        Cette section va vous aider à formaliser votre projet. Elle doit être utilisée pendant la
         phase de programmation du projet, puis révisée pendant la phase d'implantation du projet.
     </p>
     <p>
@@ -12,14 +12,14 @@
             Documentez les objectifs et résultats attendus par votre projet
         </li>
         <li>
-            Documentez les activités que vous mettrez en oeuvre pour les atteindre
+            Documentez les activités que vous mettrez en œuvre pour les atteindre
         </li>
         <li>
             Listez les indicateurs qui mesureront l'atteinte de vos résultats, ainsi que le suivi de
             vos activités (indicateurs de processus)
         </li>
         <li>
-            Listez vos outils de collecte de donnée (Excel, papier, ...) ainsi que d'autres sources
+            Listez vos outils de collecte de données (Excel, papier, ...) ainsi que d'autres sources
             de données (SNIS, enquêtes...) que vous utiliserez pour calculer vos indicateurs, en
             renseignant leur periodicité et sites de collecte et leur contenu
         </li>
@@ -127,7 +127,7 @@
                     <span translate="project.collection_form_list"></span>
                 </a>
 
-                dont vous allez extraire les données nécessaires au calculs des indicateurs de tous
+                dont vous allez extraire les données nécessaires au calcul des indicateurs de tous
                 vos cadres logiques.<br />
                 À mesure de votre avancement, mettez à jour les formules de calcul de vos
                 indicateurs dans

--- a/frontend/src/translation/en/help.js
+++ b/frontend/src/translation/en/help.js
@@ -645,7 +645,7 @@ module.exports = {
             question: `What is the purpose of the "Fill with previous period's data" button?`,
             answer: /* html */ `
                     To save time in certain specific cases!<br/>
-                    If your project follows indicators that require indicators that vary little over time (number of supported structures,
+                    If your project follows indicators that vary little over time (number of supported structures,
                     population of the targeted area, ...), it is often easier to copy the data from the previous entry and correct
                     the differences, than to enter the data from scratch.
                 `,

--- a/frontend/src/translation/en/translations.js
+++ b/frontend/src/translation/en/translations.js
@@ -162,7 +162,7 @@ export default {
     last_entry: 'Last entry',
     show_totals: 'Show totals',
     add_datasource: 'Create a new data source',
-    no_matches: 'No projects match the selected criterias',
+    no_matches: 'No projects match the selected criteria',
     is_finished: 'This project is finished',
     was_archived: 'This project was archived',
     show_ongoing_projects: 'Show ongoing projects ({{count}})',
@@ -183,7 +183,7 @@ export default {
       active_replace: "{{after ? 'Restore' : 'Delete'}} the project",
       name_replace: 'Rename the project from <code>{{before}}</code> to <code>{{after}}</code>',
       start_replace:
-        'Change the project start date of the project from <code>{{before|date}}</code> to <code>{{after|date}}</code>',
+        'Change the project start date from <code>{{before|date}}</code> to <code>{{after|date}}</code>',
       end_replace:
         'Change the project end date from <code>{{before|date}}</code> to <code>{{after|date}}</code>',
       country_replace:
@@ -307,13 +307,13 @@ export default {
       logicalFrames_purposes_add:
         'Add specific objective <code>{{item.description}}</code> to logical framework <code>{{logicalFrame.name}}</code>',
       logicalFrames_purposes_move:
-        'Reorder specific objectives of logical framwork <code>{{logicalFrame.name}}</code>',
+        'Reorder specific objectives of logical framework <code>{{logicalFrame.name}}</code>',
       logicalFrames_purposes_remove:
         'Remove specific objective <code>{{item.description}}</code> from logical framework <code>{{logicalFrame.name}}</code>',
       logicalFrames_purposes_description_replace:
         'Change description of specific objective <code>{{before}}</code> to <code>{{after}}</code> in logical framework <code>{{logicalFrame.name}}</code>',
       logicalFrames_purposes_assumptions_replace:
-        'Change assumptions of specific objective <code>{{purpose.description}}</code> de <code>{{before}}</code> to <code>{{after}}</code> in logical framework <code>{{logicalFrame.name}}</code>',
+        'Change assumptions of specific objective <code>{{purpose.description}}</code> from <code>{{before}}</code> to <code>{{after}}</code> in logical framework <code>{{logicalFrame.name}}</code>',
 
       logicalFrames_purposes_outputs_add:
         'Add result <code>{{item.description}}</code> to logical framework <code>{{logicalFrame.name}}</code>',
@@ -342,7 +342,7 @@ export default {
       logicalFrames_indicators_remove:
         'Remove indicator <code>{{item.display}}</code> from logical framework <code>{{logicalFrame.name}}</code>',
       logicalFrames_indicators_baseline_replace:
-        'Change baseline of indicator <code>{{indicator.display}}</code> from <code>{{before}}</code> vers <code>{{after}}</code> in logical framework <code>{{logicalFrame.name}}</code>',
+        'Change baseline of indicator <code>{{indicator.display}}</code> from <code>{{before}}</code> to <code>{{after}}</code> in logical framework <code>{{logicalFrame.name}}</code>',
       logicalFrames_indicators_target_replace:
         'Change target of indicator <code>{{indicator.display}}</code> from <code>{{before}}</code> to <code>{{after}}</code> in logical framework <code>{{logicalFrame.name}}</code>',
       logicalFrames_indicators_display_replace:
@@ -354,7 +354,7 @@ export default {
 
       extraIndicators_add: 'Add extra indicator <code>{{item.display}}</code>',
       extraIndicators_move: 'Reorder extra indicators',
-      extraIndicators_remove: 'Deletee extra indicator <code>{{item.display}}</code>',
+      extraIndicators_remove: 'Delete extra indicator <code>{{item.display}}</code>',
       extraIndicators_baseline_replace:
         'Change baseline of extra indicator <code>{{extraIndicator.display}}</code> from <code>{{before}}</code> to <code>{{after}}</code>',
       extraIndicators_target_replace:
@@ -368,7 +368,7 @@ export default {
     },
 
     form_error_short: 'Some fields are invalid in the form.',
-    form_persisted_short: 'You did not made changes.',
+    form_persisted_short: 'You have not made changes.',
     form_changed_short: 'You made changes.',
 
     form_error: 'Some fields are invalid in the form, fix them in order to save.',
@@ -383,7 +383,7 @@ export default {
       '<span style="font-style: italic">No data sources are ready for data entry</span>',
     general_info: 'General information',
     indicator_computation_missing: 'Calculation is missing',
-    which_variable: 'From which variable does this information comes from?',
+    which_variable: 'From which variable does this information come?',
     which_partitions: 'Which disaggregations are relevant?',
     value_unknown: 'Unknown value',
 
@@ -453,8 +453,8 @@ export default {
       year: 'Years',
       entity: 'Sites',
       group: 'Sites: {{name}}',
-      partition: 'Disagregation: {{name}}',
-      partition_group: 'Disagregation: {{name}} / {{groupName}} ',
+      partition: 'Disaggregation: {{name}}',
+      partition_group: 'Disaggregation: {{name}} / {{groupName}} ',
     },
 
     edit_user: 'User edition',
@@ -536,9 +536,9 @@ export default {
 
     periodicities: {
       day: 'Every day',
-      month_week_sat: 'Every weeks (saturday to friday / split by month)',
-      month_week_sun: 'Every weeks (sunday to saturday / split by month)',
-      month_week_mon: 'Every weeks (monday to sunday / split by month)',
+      month_week_sat: 'Every week (saturday to friday / split by month)',
+      month_week_sun: 'Every week (sunday to saturday / split by month)',
+      month_week_mon: 'Every week (monday to sunday / split by month)',
       week_sat: 'Every week (saturday to friday)',
       week_sun: 'Every week (sunday to saturday)',
       week_mon: 'Every week (monday to sunday)',
@@ -584,7 +584,7 @@ export default {
 
     specific_dates: 'Validity duration',
     specific_dates_yes: 'Use dates which are specific to this logical framework',
-    specific_dates_use_project: 'Use the same dates than the project',
+    specific_dates_use_project: 'Use the same dates as the project',
     logframe_edit_help_specificdates: `If this logical frame is valid only during a part of the project, it can be entered here`,
     logframe_edit_help_start:
       'Date from which indicators will be computed for this logical framework',
@@ -612,9 +612,9 @@ export default {
     add_purpose: 'Add a new specific objective',
 
     basics_help_country:
-      "In which country does your project takes place? If it's a regional project enter the name of the region.",
+      "In which country does your project take place? If it's a regional project, enter the name of the region.",
     basics_help_name:
-      "The project's name allow finding your project in Monitool. Choose something that is informative enought, or copy the general objective.",
+      "The project's name allows finding your project in Monitool. Choose something that is informative enough, or copy the general objective.",
     basics_help_begin:
       'The begin date is the moment when your projects starts collecting data (usually, with the first activities)',
     basics_help_end:
@@ -625,7 +625,7 @@ export default {
     collection_edit_help_sites:
       'Among sites identified in "Collection sites", which one collect this data source?',
     collection_edit_help_periodicity:
-      'How often is this data available? Take care, this is not the same thing as the frenquency of the reports that you need to provide.',
+      'How often is this data available? Take care, this is not the same thing as the frequency of the reports that you need to provide.',
 
     collection_edit_help_varname:
       'Name the variable that you want to extract from <code>{{name}}</code>. i.e. "Number of diagnostics".',
@@ -634,7 +634,7 @@ export default {
     collection_edit_help_timeagg:
       'In a project collecting monthly data, if <code>{{name}}</code> is 10 in january, 20 in february and 30 in march, what is the value for the first quarter?',
     collection_edit_help_partition:
-      'Do we want to be able to differenciate <code>{{name}}</code> by age, gender, type of care, consultation motive, pathology, hour of the day, referral type, ...?<br/>Do not disaggregate by location: your collection sites were already filled in the relevant page.',
+      'Do we want to be able to differentiate <code>{{name}}</code> by age, gender, type of care, consultation motive, pathology, hour of the day, referral type, ...?<br/>Do not disaggregate by location: your collection sites were already filled in the relevant page.',
     collection_edit_help_distribution:
       'If you wish to print the forms in A4 format, prefer having the titles at the left of the tables, to shorten their width.',
     collection_edit_help_order: 'How do you wish to show the disaggregations on the input form?',
@@ -644,12 +644,12 @@ export default {
 
     titles: 'Titles',
     data: 'Data',
-    general_informations: 'General informations',
+    general_informations: 'General information',
     fill_from_last: 'Previous entry',
     fill_from_upload: 'Uploaded file',
     fill_with_zeros: 'Zeros',
 
-    variable_name_label: 'What are your measuring?',
+    variable_name_label: 'What are you measuring?',
     variable_name_ph: 'ex: Number of diagnostics',
     site_agg_label: 'How to group entries from different sites?',
     time_agg_label: 'How to group entries from different periods?',
@@ -680,7 +680,7 @@ export default {
     activity_desc_ph: 'e.g. Awareness sessions on HIV transmission',
     logframe_help_activity_desc: 'Activity realized by the NGO',
     logframe_help_activity_indicators:
-      'Enter here the indicators that allows to measure the activity progress',
+      'Enter here the indicators that allow measuring the activity progress',
 
     form_is_not_associated_with_site:
       'This data source is not associated with any collection site.',

--- a/frontend/src/translation/es/translations.js
+++ b/frontend/src/translation/es/translations.js
@@ -1,11 +1,11 @@
 export default {
   shared: {
-    yes: 'Si',
+    yes: 'Sí',
     no: 'No',
     archive: 'Archivar',
     enable: 'Activar',
-    disable: 'Deactivar',
-    accept_invitation: 'Acceptar',
+    disable: 'Desactivar',
+    accept_invitation: 'Aceptar',
     refuse_invitation: 'Declinar',
     uninvite: 'Eliminar de mis proyectos',
     no_invitations: 'No tiene invitaciones pendientes!',
@@ -45,7 +45,7 @@ export default {
 
     add: 'Añadir',
     save: 'Guardar',
-    save_and_archive_doc: 'Guardar e archivar el formulario',
+    save_and_archive_doc: 'Guardar y archivar el formulario',
     remove: 'Quitar',
     remove_changes: 'Cancelar los cambios',
     edit: 'Modificar',
@@ -60,7 +60,7 @@ export default {
 
     logout: 'Desconectar',
 
-    sure_to_leave: 'Ha realizado cambios. ¿Esta seguro de querer cambiar de página sin guardar?',
+    sure_to_leave: 'Ha realizado cambios. ¿Está seguro de querer cambiar de página sin guardar?',
   },
   menu: {
     language: 'Idiomas',
@@ -69,7 +69,7 @@ export default {
     english: 'Inglés',
   },
   welcome: {
-    i_got_it: 'He entendido, ¡Empezemos!',
+    i_got_it: 'He entendido, ¡Empecemos!',
     text: /* html */ `
             <legend>¡Bienvenido!</legend>
             <p>Es su primera visita a Monitool.</p>
@@ -125,7 +125,7 @@ export default {
     uploads: 'Formularios en papel y Excel',
 
     drop_file_here:
-      'Solte sus formularios completados aquí o <label for="file-input">elija archivos</label>',
+      'Suelte sus formularios completados aquí o <label for="file-input">elija archivos</label>',
     drop_file_here_formats:
       'Formatos admitidos: foto, escaneo, fax (pdf, jpg, png, tiff), excel (xlsx) o archivo (zip).',
     waiting_dataentry: 'Esperando entrada',
@@ -145,7 +145,7 @@ export default {
     prefill_with: 'Rellenar con: ',
     original_file: 'Fichero original',
     load_data: 'Cargar datos',
-    no_logframe_yet: 'Aún no ha creado ningún marco logico en este proyecto',
+    no_logframe_yet: 'Aún no ha creado ningún marco lógico en este proyecto',
     show_all_projects: 'Mostrar todos los proyectos ({{count}})',
     no_projects: 'No tiene ningún proyecto',
     download_portrait: 'Descargar PDF (vertical)',
@@ -157,14 +157,14 @@ export default {
     confirm_delete_datasource: `Si elimina esta fuente de datos, ya no podrá acceder a sus datos en informes o a los indicadores que dependen de ella. Confirme para eliminar.`,
     total: 'Total',
     variables: 'Variables',
-    owner: 'Proprietario',
+    owner: 'Propietario',
     invitations: 'Invitaciones',
     downloads: 'Descargas',
     last_entry: 'Última entrada',
     show_totals: 'Mostrar totales',
     add_datasource: 'Crear una nueva fuente de datos',
     no_matches: 'Ningún proyecto corresponde a sus criterios de búsqueda',
-    is_finished: 'Este proyecto esta terminado',
+    is_finished: 'Este proyecto está terminado',
     was_archived: 'Este proyecto fue archivado',
     show_ongoing_projects: 'Mostrar proyectos en curso ({{count}})',
     show_finished_projects: 'Mostrar proyectos terminados ({{count}})',
@@ -178,7 +178,7 @@ export default {
     revision_save_to_confirm: 'Guarde para confirmar que desea volver a este punto',
     revision_is_equivalent: 'Este punto es equivalente al estado actual del proyecto',
     revision_none: 'No hay historial en este proyecto',
-    revision_show_more: 'Ver cambios mas antiguos',
+    revision_show_more: 'Ver cambios más antiguos',
 
     history: {
       active_replace: "{{after ? 'Restaura' : 'Elimina'}} el proyecto",
@@ -203,7 +203,7 @@ export default {
       groups_move: 'Reordena los grupos del proyecto',
       groups_remove: 'Elimina el grupo <code>{{item.name}}</code>',
       groups_name_replace:
-        'Cambia el nombre del groupo <code>{{before}}</code> en <code>{{after}}</code>',
+        'Cambia el nombre del grupo <code>{{before}}</code> en <code>{{after}}</code>',
       groups_members_add:
         'Añade el lugar <code>{{item.name}}</code> al grupo <code>{{group.name}}</code>',
       groups_members_move: 'Reordena los lugares del grupo <code>{{group.name}}</code>',
@@ -213,7 +213,7 @@ export default {
       forms_add: 'Añade la fuente de datos <code>{{item.name}}</code>',
       forms_move: 'Reordena las fuentes de datos del proyecto',
       forms_replace:
-        'Reemplaca la fuente de datos <code>{{before.name}}</code> por <code>{{after.name}}</code>',
+        'Reemplaza la fuente de datos <code>{{before.name}}</code> por <code>{{after.name}}</code>',
       forms_remove: 'Elimina la fuente de datos <code>{{item.name}}</code>',
       forms_name_replace:
         'Cambia el nombre de la fuente de datos <code>{{before}}</code> en <code>{{after}}</code>',
@@ -228,14 +228,14 @@ export default {
       forms_entities_remove:
         'Elimina el lugar <code>{{item.name}}</code> de la fuente de datos <code>{{form.name}}</code>',
       forms_entities_replace:
-        'Reemplaca el lugar <code>{{beforeItem.name}}</code> por <code>{{afterItem.name}}</code> en la fuente de datos <code>{{form.name}}</code>',
+        'Reemplaza el lugar <code>{{beforeItem.name}}</code> por <code>{{afterItem.name}}</code> en la fuente de datos <code>{{form.name}}</code>',
 
       forms_elements_add:
         'Añade la variable <code>{{item.name}}</code> en <code>{{form.name}}</code>',
       forms_elements_move:
         'Reordena las variables de la fuente de datos <code>{{form.name}}</code>',
       forms_elements_replace:
-        'Remplaca la variable <code>{{before.name}}</code> por <code>{{after.name}}</code> en la fuente de datos <code>{{form.name}}</code>',
+        'Reemplaza la variable <code>{{before.name}}</code> por <code>{{after.name}}</code> en la fuente de datos <code>{{form.name}}</code>',
       forms_elements_remove:
         'Elimina la variable <code>{{item.name}}</code> en <code>{{form.name}}</code>',
 
@@ -281,7 +281,7 @@ export default {
       forms_elements_partitions_groups_remove:
         'Elimina el grupo <code>{{item.name}}</code> en la desagregación <code>{{partition.name}}</code> de la variable <code>{{variable.name}}</code>',
       forms_elements_partitions_groups_name_replace:
-        'Cambia el nombre del groupo <code>{{before}}</code> en <code>{{after}}</code> en la desagregación <code>{{partition.name}}</code> de la variable <code>{{variable.name}}</code>',
+        'Cambia el nombre del grupo <code>{{before}}</code> en <code>{{after}}</code> en la desagregación <code>{{partition.name}}</code> de la variable <code>{{variable.name}}</code>',
       forms_elements_partitions_groups_members_add:
         'Añade <code>{{item.name}}</code> al grupo <code>{{group.name}}</code> en la desagregación <code>{{partition.name}}</code> de la variable <code>{{variable.name}}</code>',
       forms_elements_partitions_groups_members_move:
@@ -303,22 +303,22 @@ export default {
       logicalFrames_name_replace:
         'Cambia el nombre del marco lógico <code>{{before}}</code> en <code>{{after}}</code>',
       logicalFrames_goal_replace:
-        'Cambia el objectivo general <code>{{before}}</code> en <code>{{after}}</code> en el marco lógico <code>{{logicalFrame.name}}</code>',
+        'Cambia el objetivo general <code>{{before}}</code> en <code>{{after}}</code> en el marco lógico <code>{{logicalFrame.name}}</code>',
       logicalFrames_start_replace:
         'Cambia el inicio <code>{{before}}</code> en <code>{{after}}</code> en el marco lógico <code>{{logicalFrame.name}}</code>',
       logicalFrames_end_replace:
         'Cambia el final <code>{{before}}</code> en <code>{{after}}</code> en el marco lógico <code>{{logicalFrame.name}}</code>',
 
       logicalFrames_purposes_add:
-        'Añade el objectivo especifico <code>{{item.description}}</code> al marco lógico <code>{{logicalFrame.name}}</code>',
+        'Añade el objetivo específico <code>{{item.description}}</code> al marco lógico <code>{{logicalFrame.name}}</code>',
       logicalFrames_purposes_move:
-        'Reordena los objectivos especificos del marco lógico <code>{{logicalFrame.name}}</code>',
+        'Reordena los objetivos específicos del marco lógico <code>{{logicalFrame.name}}</code>',
       logicalFrames_purposes_remove:
-        'Elimina el objectivo especifico <code>{{item.description}}</code> del marco lógico <code>{{logicalFrame.name}}</code>',
+        'Elimina el objetivo específico <code>{{item.description}}</code> del marco lógico <code>{{logicalFrame.name}}</code>',
       logicalFrames_purposes_description_replace:
-        'Cambia la descripción del objectivo especifico <code>{{before}}</code> en <code>{{after}}</code> en el marco lógico <code>{{logicalFrame.name}}</code>',
+        'Cambia la descripción del objetivo específico <code>{{before}}</code> en <code>{{after}}</code> en el marco lógico <code>{{logicalFrame.name}}</code>',
       logicalFrames_purposes_assumptions_replace:
-        'Cambia las hypotesis del objectivo especifico <code>{{purpose.description}}</code> de <code>{{before}}</code> en <code>{{after}}</code> en el marco lógico <code>{{logicalFrame.name}}</code>',
+        'Cambia las hipótesis del objetivo específico <code>{{purpose.description}}</code> de <code>{{before}}</code> en <code>{{after}}</code> en el marco lógico <code>{{logicalFrame.name}}</code>',
 
       logicalFrames_purposes_outputs_add:
         'Añade el resultado <code>{{item.description}}</code> al marco lógico <code>{{logicalFrame.name}}</code>',
@@ -329,7 +329,7 @@ export default {
       logicalFrames_purposes_outputs_description_replace:
         'Cambia la descripción del resultado <code>{{before}}</code> en <code>{{after}}</code> en el marco lógico <code>{{logicalFrame.name}}</code>',
       logicalFrames_purposes_outputs_assumptions_replace:
-        'Cambia las hypotesis del resultado <code>{{output.description}}</code> de <code>{{before}}</code> a <code>{{after}}</code> en el marco lógico <code>{{logicalFrame.name}}</code>',
+        'Cambia las hipótesis del resultado <code>{{output.description}}</code> de <code>{{before}}</code> a <code>{{after}}</code> en el marco lógico <code>{{logicalFrame.name}}</code>',
 
       logicalFrames_purposes_outputs_activities_add:
         'Añade la actividad <code>{{item.description}}</code> al marco lógico <code>{{logicalFrame.name}}</code>',
@@ -358,7 +358,7 @@ export default {
         'Cambia el cálculo del indicador <code>{{indicator.display}}</code> del marco lógico <code>{{logicalFrame.name}}</code>',
 
       extraIndicators_add: 'Añade el indicador adicional <code>{{item.display}}</code>',
-      extraIndicators_move: 'Reordena les indicadores adicionales',
+      extraIndicators_move: 'Reordena los indicadores adicionales',
       extraIndicators_remove: 'Elimina el indicador adicional <code>{{item.display}}</code>',
       extraIndicators_baseline_replace:
         'Cambia el valor inicial del indicador adicional <code>{{extraIndicator.display}}</code> de <code>{{before}}</code> a <code>{{after}}</code>',
@@ -372,24 +372,24 @@ export default {
         'Cambia el cálculo del indicador adicional <code>{{extraIndicator.display}}</code>',
     },
 
-    form_error_short: 'Algunos campos del formulario no son validos.',
+    form_error_short: 'Algunos campos del formulario no son válidos.',
     form_persisted_short: 'No ha realizado cambios.',
     form_changed_short: 'Ha realizado cambios.',
 
-    form_error: 'Algunos campos del formulario no son validos, arreglelos para poder guardar.',
-    form_persisted: 'Sus datos estan guardados.',
+    form_error: 'Algunos campos del formulario no son válidos, arreglelos para poder guardar.',
+    form_persisted: 'Sus datos están guardados.',
     form_changed: 'Ha realizado cambios. No olvide hacer click en Guardar.',
 
-    show_more_inputs: 'Ver la fechas anteriores',
+    show_more_inputs: 'Ver las fechas anteriores',
     all_elements: 'Todo',
     no_extra_indicators: 'Ningún indicador adicional ha sido creado.',
     no_data_source_yet: 'Ninguna fuente de datos ha sido creada.',
     no_data_source:
-      '<span style="font-style: italic">Ninguna fuente de datos esta lista para entrar datos</span>',
+      '<span style="font-style: italic">Ninguna fuente de datos está lista para entrar datos</span>',
     general_info: 'Información general',
     indicator_computation_missing: 'Falta el cálculo',
-    which_variable: 'De que variable viene esta información?',
-    which_partitions: 'Qué desagregaciones son relevantes?',
+    which_variable: '¿De qué variable viene esta información?',
+    which_partitions: '¿Qué desagregaciones son relevantes?',
     value_unknown: 'Valor desconocido',
 
     computations: {
@@ -397,7 +397,7 @@ export default {
       copy: 'Copiar un valor (desde una fuente de datos)',
       percentage: 'Porcentaje (desde fuentes de datos)',
       permille: 'Por mil (desde fuentes de datos)',
-      formula: 'Formula personalizada (desde fuentes de datos)',
+      formula: 'Fórmula personalizada (desde fuentes de datos)',
     },
 
     formula: {
@@ -411,24 +411,24 @@ export default {
 
     partition_edit: 'Edición desagregación',
     partition_help_name:
-      'Este nombre aparecera en varios informes. Identifica la desagregación que desea crear en su variable',
+      'Este nombre aparecerá en varios informes. Identifica la desagregación que desea crear en su variable',
     partition_help_elements:
       'Los elementos de la desagregación deben ser mutualmente exclusivos, y se debe poder calcular el valor total agregandolos.',
-    partition_help_aggregation: 'Como calcular el valor total agregando los elementos describidos?',
+    partition_help_aggregation: '¿Cómo calcular el valor total agregando los elementos descritos?',
     partition_help_groups: 'Los grupos permiten hacer agregaciones intermediarias',
     logical_frame: 'Marco lógico',
 
     no_data: 'Datos no disponibles',
 
     saving_failed:
-      'No se pudieron guardar los cambios, probablemente porque no esta conectado a internet. Intente guardar de nuevo cuando se conecte a internet.',
+      'No se pudieron guardar los cambios, probablemente porque no está conectado a internet. Intente guardar de nuevo cuando se conecte a internet.',
 
     partition_general: 'General',
     partition_general_placeholder: 'ej: Grupos de edad, sexo, motivo de consulta, patología, ...',
     partition_elements: 'Elementos',
-    aggregation_lab: 'Como compilar los elements juntos?',
+    aggregation_lab: '¿Cómo agrupar los elementos juntos?',
     partition_name: 'Nombre',
-    partition_name_placeholder: 'ex: Menor de 12 años, hombre, consultación social, gripe, ...',
+    partition_name_placeholder: 'ej: Menor de 12 años, hombre, consulta social, gripe, ...',
     no_partition_elements: 'Pulse "Añadir" para añadir un elemento en la desagregación',
 
     partition_group_name: 'Nombre',
@@ -438,8 +438,8 @@ export default {
 
     no_inputs: 'Ninguna entrada de datos en espera',
     no_variable:
-      'Ninguna variable esta definida en esta fuente de datos. ¡Haga click en "Añadir una variable" para create una nueva!',
-    no_partitions: 'Ninguna desagregación esta definida en esta variable',
+      'Ninguna variable está definida en esta fuente de datos. ¡Haga clic en "Añadir una variable" para crear una nueva!',
+    no_partitions: 'Ninguna desagregación está definida en esta variable',
 
     dimensions: {
       day: 'Días',
@@ -459,7 +459,7 @@ export default {
       partition_group: 'Desagregación: {{name}} / {{groupName}}',
     },
 
-    parameter: 'Parametro',
+    parameter: 'Parámetro',
     unnamed_logframe: 'Marco lógico sin nombre',
 
     edit_indicator: 'Editar indicador',
@@ -469,7 +469,7 @@ export default {
 
     show_finished: 'Ver todas las entradas',
     are_you_sure_to_uninvite:
-      '¿Esta seguro de querer quitar este proyecto de su lista? El proprietario debera invitarle de nuevo si necesita tener acceso. Confirme para quitarlo',
+      '¿Está seguro de querer quitar este proyecto de su lista? El propietario deberá invitarle de nuevo si necesita tener acceso. Confirme para quitarlo',
     data_selection: 'Seleccione los datos',
     filters: 'Filtros',
     input_status: {
@@ -477,10 +477,10 @@ export default {
       expected: 'Crear',
     },
     cols: 'Columnas',
-    rows: 'Linear',
+    rows: 'Líneas',
     entity: 'Lugar de colecta',
-    select_cols: 'Selecione las columnas',
-    select_rows: 'Selecione las lineas',
+    select_cols: 'Seleccione las columnas',
+    select_rows: 'Seleccione las líneas',
     pivot_table: 'Tabla dinámica',
 
     groups: 'Grupos',
@@ -517,7 +517,7 @@ export default {
 
     variable: 'Variable',
 
-    no_purposes: 'Ningun objetivo específico ha sido definido',
+    no_purposes: 'Ningún objetivo específico ha sido definido',
 
     form_name_ph: 'ej: Datos SNIS, Ficha de colecta ante-natal, Ficha sanidad primaria, ...',
 
@@ -551,10 +551,10 @@ export default {
     input: 'Entrar datos',
 
     baseline: 'Valor de base',
-    target: 'Objectivo',
+    target: 'Objetivo',
 
-    goal: 'Objectivo global',
-    intervention_logic: 'Logica de intervención',
+    goal: 'Objetivo global',
+    intervention_logic: 'Lógica de intervención',
 
     start_date: 'Fecha de inicio',
     end_date: 'Fecha de fin',
@@ -562,18 +562,18 @@ export default {
     name_ph: 'ej: Acceso a atención de calidad para las personas afectadas por la crisis',
     add_indicator: 'Añadir un indicador',
 
-    purpose: 'Objectivo específico',
-    purposes: 'Objectivos específicos',
-    assumptions: 'Hipotesis',
+    purpose: 'Objetivo específico',
+    purposes: 'Objetivos específicos',
+    assumptions: 'Hipótesis',
     output: 'Resultado',
 
-    indicator_is_computed: 'Valido',
-    indicator_is_not_computed: 'Invalido',
+    indicator_is_computed: 'Válido',
+    indicator_is_not_computed: 'Inválido',
 
     intervention_logic_goal_ph:
       'ej. Reducir la mortalidad y la morbididad de la población afectada por la crisis',
     intervention_logic_purpose_ph:
-      'ej. Mejorar el acceso a la salud para la población afectada por la crisis en los districtos de Bimbo y Begoua',
+      'ej. Mejorar el acceso a la salud para la población afectada por la crisis en los distritos de Bimbo y Begoua',
     output_desc_ph:
       'ej. Mejorar la atención de salud primaria en los centros de salud de Bimbo y Begoua',
     assumptions_purpose_ph: '',
@@ -587,57 +587,57 @@ export default {
     logframe_edit_help_start:
       'Fecha a partir de la cual desea calcular los indicadores para este marco lógico',
     logframe_edit_help_end:
-      'Fecha hasta la que desea calcular los indicadores de este marco lógico se calcularán',
+      'Fecha hasta la que desea calcular los indicadores de este marco lógico',
 
     logframe_help_sites:
-      'Entre los lugares identificados en "Lugares de colecta", cuales son relevantes para este marco lógico?',
+      'Entre los lugares identificados en "Lugares de colecta", ¿cuáles son relevantes para este marco lógico?',
     logframe_help_name:
-      'Nombre este marco lógico para poder identificarlo facilment. Por ejemplo con el nombre del donante relevante',
+      'Nombre este marco lógico para poder identificarlo fácilmente. Por ejemplo con el nombre del donante relevante',
     logframe_help_goal:
-      'Descripción de la contribución del proyecto a los objectivos (impacto) de una política o de un programa',
-    logframe_help_goal_indicators: 'Entre los indicadores que permiten medir el objectivo general',
+      'Descripción de la contribución del proyecto a los objetivos (impacto) de una política o de un programa',
+    logframe_help_goal_indicators: 'Entre los indicadores que permiten medir el objetivo general',
     logframe_help_purpose_desc:
       'Describa las ventajas tangibles que se proporcionan a los beneficiarios',
     logframe_help_purpose_assumptions:
-      'Factores externos susceptibles de comprometer el alcanze del objectivo específico',
+      'Factores externos susceptibles de comprometer el alcance del objetivo específico',
     logframe_help_purpose_indicators:
-      'Entre los indicadores que permiten medir el objectivo específico',
+      'Entre los indicadores que permiten medir el objetivo específico',
     logframe_help_output_desc: 'Producto o servicio tangible proporcionado por el proyecto',
     logframe_help_output_assumptions:
-      'Factores externos susceptibles de comprometer el alcanze del resultado',
+      'Factores externos susceptibles de comprometer el alcance del resultado',
     logframe_help_output_indicators: 'Entre los indicadores que permiten medir el resultado',
 
     add_output: 'Añadir un resultado',
     add_purpose: 'Añadir un objetivo específico',
 
     basics_help_country:
-      'En que país tiene lugar su proyecto? Si es un proyecto regional, entre el nombre de la región.',
+      '¿En qué país tiene lugar su proyecto? Si es un proyecto regional, entre el nombre de la región.',
     basics_help_name:
-      'El nombre del proyecto le permite encontrarlo en Monitool. Elija algo que sea suficientemente informativo, o copie el objectivo general.',
+      'El nombre del proyecto le permite encontrarlo en Monitool. Elija algo que sea suficientemente informativo, o copie el objetivo general.',
     basics_help_begin:
-      'La fecha de inicio es el momento en el que su proyecto empieza a colectar datos (usualemente, con la primeras actividades)',
+      'La fecha de inicio es el momento en el que su proyecto empieza a recolectar datos (usualmente, con las primeras actividades)',
     basics_help_end:
       'La fecha de fin es el momento en el que termina la colecta de datos. Si no es conocida, entre una fecha en el futuro.',
 
     collection_edit_help_name:
-      'Cual es el nombre de la fuente de datos de la que quiere extraer datos? ej. "Historiales clínicos electronicos", "Fichas de colecta", "Informe SNIS", ...',
+      '¿Cuál es el nombre de la fuente de datos de la que quiere extraer datos? ej. "Historiales clínicos electrónicos", "Fichas de colecta", "Informe SNIS", ...',
     collection_edit_help_sites:
-      'Entre los lugares identificados en "Lugares de colecta", cuales son los que colectan esta fuente de datos?',
+      'Entre los lugares identificados en "Lugares de colecta", ¿cuáles son los que recolectan esta fuente de datos?',
     collection_edit_help_periodicity:
-      'Cada cuanto son disponibles estos datos? Tenga ciudado, no entre aqui la frecuencia a la que hace sus informes.',
+      '¿Cada cuánto están disponibles estos datos? Tenga cuidado, no entre aquí la frecuencia a la que hace sus informes.',
 
     collection_edit_help_varname:
-      'Nombre la variable que quiere extraer de <code>{{name}}</code>. ej: "Número de diagnosticos".',
+      'Nombre la variable que quiere extraer de <code>{{name}}</code>. ej: "Número de diagnósticos".',
     collection_edit_help_geoagg:
       'En un proyecto que trabaja en dos lugares, si <code>{{name}}</code> vale 10 en el primero, y 20 en el segundo, cual es el valor para el proyecto entero?',
     collection_edit_help_timeagg:
-      'En un proyecto que colecta datos mensuales, si <code>{{name}}</code> vale 10 en enero, 20 en febrero y 30 en marzo, que vale para el trimer trimestre?',
+      'En un proyecto que recolecta datos mensuales, si <code>{{name}}</code> vale 10 en enero, 20 en febrero y 30 en marzo, ¿qué vale para el primer trimestre?',
     collection_edit_help_partition:
       '¿Quiere poder diferenciar <code>{{name}}</code> por edad, sexo, tipo de consulta, motivo de consulta, patología, hora del dia, ...? <br/>No desagrege por zona geográfica: los lugares de colecta ya se rellenaron en la otra página.',
     collection_edit_help_distribution:
-      'Si va a imprimir formulario en A4, prefiera tener columnas a la izquierda para que las tablas sean menor anchas.',
+      'Si va a imprimir formularios en A4, prefiera tener los títulos a la izquierda para que las tablas sean menos anchas.',
     collection_edit_help_order:
-      'En que ordén quiere que aparescan la desagregaciones en las tablas de entrada de datos?',
+      '¿En qué orden quiere que aparezcan las desagregaciones en las tablas de entrada de datos?',
 
     download_portrait: 'Descargar PDF (vertical)',
     download_landscape: 'Descargar PDF (horizontal)',
@@ -650,40 +650,40 @@ export default {
     fill_from_upload: 'Formulario cargado',
     fill_with_zeros: 'Cero',
 
-    variable_name_label: 'Qué esta midiendo?',
-    variable_name_ph: 'ej: Número de diagnosticos',
-    site_agg_label: 'Como compilar entradas provenientes de diferentes lugares?',
-    time_agg_label: 'Como compilar entradas provenientes de diferentes periodos?',
-    partitions_label: 'Que desagregaciones quiere usar en esta variable?',
-    distribution_label: 'Como mostrar la desagregaciones en el formulario de colecta?',
-    order_label: 'En que ordén mostrar las desagregaciones en el formulario de colecta?',
-    delete_purpose: 'Suprimir el objectivo especifico',
+    variable_name_label: '¿Qué está midiendo?',
+    variable_name_ph: 'ej: Número de diagnósticos',
+    site_agg_label: '¿Cómo agrupar entradas provenientes de diferentes lugares?',
+    time_agg_label: '¿Cómo agrupar entradas provenientes de diferentes periodos?',
+    partitions_label: '¿Qué desagregaciones quiere usar en esta variable?',
+    distribution_label: '¿Cómo mostrar las desagregaciones en el formulario de colecta?',
+    order_label: '¿En qué orden mostrar las desagregaciones en el formulario de colecta?',
+    delete_purpose: 'Suprimir el objetivo específico',
     delete_result: 'Suprimir el resultado',
 
-    no_element_selected: 'Ningún elemento esta seleccionado',
+    no_element_selected: 'Ningún elemento está seleccionado',
 
     indicator_ph_fixed: 'Entre el valor constante del indicador (ej: "12")',
     indicator_help_description: 'Contexto de colecta, detalles sobre el método de cálculo...',
     indicator_help_display:
       'Nombre su indicador. Es preferible obtener el nombre a partir de un catalogo para ser consistente con otros proyectos.',
     indicator_help_baseline:
-      'Cual era el valor del indicador antes de empezar la actividades? Marque la casilla para especificar un valor.',
+      '¿Cuál era el valor del indicador antes de empezar las actividades? Marque la casilla para especificar un valor.',
     indicator_help_target:
-      'Cual es el objectivo para este indicador? Marque la casilla para especificar un valor.',
+      '¿Cuál es el objetivo para este indicador? Marque la casilla para especificar un valor.',
     indicator_help_colorize:
-      'Desea tener colores (rojo, naranja, verde) en informes para este indicador?',
+      '¿Desea tener colores (rojo, naranja, verde) en informes para este indicador?',
     indicator_help_computation:
-      'Como se calcula este indicador a partir de las variables que ha colectado en fuentes de datos?',
+      '¿Cómo se calcula este indicador a partir de las variables que ha recolectado en fuentes de datos?',
 
     activity: 'Actividad',
     add_activity: 'Añadir una actividad',
     delete_activity: 'Suprimir la actividad',
-    activity_desc_ph: 'ej. Realizar sesiones de sensibilización sobre la transmision del VIH',
+    activity_desc_ph: 'ej. Realizar sesiones de sensibilización sobre la transmisión del VIH',
     logframe_help_activity_desc: 'Actividad realizada por la ONG',
     logframe_help_activity_indicators: 'Entre los indicadores que permiten medir la actividad',
 
     form_is_not_associated_with_site:
-      'Esta fuente de datos no esta asociada a ningún lugar de colecta.',
+      'Esta fuente de datos no está asociada a ningún lugar de colecta.',
   },
 
   form: {

--- a/frontend/src/translation/fr/help.js
+++ b/frontend/src/translation/fr/help.js
@@ -26,14 +26,14 @@ module.exports = {
             title: 'Lieux de collecte',
             paragraph: /* html */ `
             <p>
-                Lorsqu'un projet réalise les même activités dans plusieurs lieux, celles-ci doivent pouvoir être
-                suivi individuellements, par groupes, et tous ensembles.
+                Lorsqu'un projet réalise les mêmes activités dans plusieurs lieux, celles-ci doivent pouvoir être
+                suivies individuellement, par groupes, et toutes ensemble.
             </p>
             <p>
                 Rentrez ici:
                 <ul>
                     <li>La liste des lieux sur lesquels le projet travaille (par exemple: une liste des centres de santé)</li>
-                    <li>Des groupements qui seront utilisé lors du suivi (par exemple: des régions, des types de structure)</li>
+                    <li>Des groupements qui seront utilisés lors du suivi (par exemple: des régions, des types de structure)</li>
                 </ul>
             </p>`,
         },
@@ -56,8 +56,8 @@ module.exports = {
         'project.config.logical_frame_list': {
             title: 'Liste des cadres logiques',
             paragraph: /* html */ `
-                Un cadre logique est un document qui décrit les objectifs, les résultats attendus, et les activités misent
-                en oeuvre pour y parvenir, ainsi que les indicateurs qui permette de suivre l'avancement de chaque élément.<br/>
+                Un cadre logique est un document qui décrit les objectifs, les résultats attendus, et les activités mises
+                en œuvre pour y parvenir, ainsi que les indicateurs qui permettent de suivre l'avancement de chaque élément.<br/>
                 Tous les indicateurs présents dans les cadres logiques doivent être calculables à partir des données 
                 décrites dans les sources de données
             `,
@@ -105,7 +105,7 @@ module.exports = {
         },
         'project.usage.preview': {
             title: `Historique des modifications`,
-            paragraph: /* html */ `Cette page vous permet de Visualiser les modifications réalisée lors d'une saisie en particulier.`,
+            paragraph: /* html */ `Cette page vous permet de visualiser les modifications réalisées lors d'une saisie en particulier.`,
         },
         'project.usage.uploads': {
             title: `Téléversement de fichiers`,
@@ -113,7 +113,7 @@ module.exports = {
         },
         'project.usage.list': {
             title: `Calendrier de saisie`,
-            paragraph: /* html */ `Le calendrier de saisie permet d'accèder aux fiches de saisie du projet`,
+            paragraph: /* html */ `Le calendrier de saisie permet d'accéder aux fiches de saisie du projet`,
         },
         'project.usage.edit': {
             title: `Édition d'une saisie`,
@@ -125,12 +125,12 @@ module.exports = {
         },
         'project.usage.general': {
             title: `Rapport général`,
-            paragraph: /* html */ `Cette page vous permet d'explorer vos données hierarchiquement en partant d'une vision général de votre projet.`,
+            paragraph: /* html */ `Cette page vous permet d'explorer vos données hiérarchiquement en partant d'une vision générale de votre projet.`,
         },
         'project.usage.olap': {
             title: `Tableau croisé dynamique`,
             paragraph: /* html */ `Cette page vous permet de construire des tableaux qui prendront la forme que vous désirez, et de les télécharger
-            en format Excel, afin de les inclure dans des rapports ou de créer des visualisation en dehors de Monitool.`,
+            en format Excel, afin de les inclure dans des rapports ou de créer des visualisations en dehors de Monitool.`,
         },
     },
     qas: [
@@ -148,15 +148,15 @@ module.exports = {
             question: `Pourquoi peut-on créer plusieurs projets par compte, alors qu'un seul suffit?`,
             answer: /* html */ `
                 Ça n'a pas d'utilité d'un point de vue terrain, mais certains utilisateurs doivent pouvoir accéder 
-                à de nombreux projets qu'ils ne crée pas eux-même.<br/>
-                Notament des salariés siège, régionaux ou des consultants
+                à de nombreux projets qu'ils ne créent pas eux-mêmes.<br/>
+                Notamment des salariés siège, régionaux ou des consultants
             `,
         },
         {
             prefixes: ['main.projects'],
             question: `Comment retourner sur les pages de configuration sur un projet que j'ai déjà créé?`,
             answer: /* html */ `
-                Sur votre projet, à droite du bouton ouvrir, clickez sur
+                Sur votre projet, à droite du bouton ouvrir, cliquez sur
                 <span class="btn btn-default btn-xs"><span class="caret"></span></span>
                 pour les voir toutes les actions possibles.
             `,
@@ -165,21 +165,21 @@ module.exports = {
             prefixes: ['main.projects'],
             question: `Quelle est l'utilité de pouvoir "Cloner la structure" d'un projet?`,
             answer: /* html */ `
-                La fonctionalité "Cloner la structure uniquement" est pensée pour les ONGs qui réalisent des 
-                programmes d'urgence. En effet dans ce cas, plutot que de prendre le temps de réflexion nécessaire
+                La fonctionnalité "Cloner la structure uniquement" est pensée pour les ONG qui réalisent des
+                programmes d'urgence. En effet dans ce cas, plutôt que de prendre le temps de réflexion nécessaire
                 à la construction d'un projet, il est fréquent de créer en avance différents
                 squelettes de projets avec toutes les sources de données et le cadre logique prêts à l'emploi.
                 <br/>
-                Lorsqu'une nouvelle crise démarre le système de monitoring peut ainsi être opérationel en quelques
+                Lorsqu'une nouvelle crise démarre le système de monitoring peut ainsi être opérationnel en quelques
                 minutes. Il suffit alors de cloner la structure du squelette adapté à la situation, et de renommer le projet,
-                l'adaptation du projet au contexte viendra dans une phase ultérieur du projet.
+                l'adaptation du projet au contexte viendra dans une phase ultérieure du projet.
             `,
         },
         {
             prefixes: ['main.projects'],
             question: `Quelle est l'utilité de pouvoir "Cloner structure et données" d'un projet?`,
             answer: /* html */ `
-                La fonctionalité "Cloner structure et données" intervient géneralement au moment d'un changement
+                La fonctionnalité "Cloner structure et données" intervient généralement au moment d'un changement
                 de bailleur ou un changement majeur dans l'appareil de monitoring d'un projet long terme.<br/>
                 Il permet de prendre une photographie d'un projet, avec sa structure et toutes ses saisies à un instant donné
                 et à la conserver dans le long terme.
@@ -187,7 +187,7 @@ module.exports = {
         },
         {
             prefixes: ['main.projects'],
-            question: `J'ai archivé mon projet par erreur, comment le récuperer?`,
+            question: `J'ai archivé mon projet par erreur, comment le récupérer?`,
             answer: /* html */ `
                 Cliquez sur <span class="btn btn-default btn-xs">Afficher les projets archivés</span>,
                 puis sur <span class="btn btn-default btn-xs">Restaurer</span>
@@ -219,7 +219,7 @@ module.exports = {
                 <ul>
                     <li>Votre projet ne correspond pas au filtre que vous avez rentré. Videz la barre de saisie de texte en haut de la page</li>
                     <li>Votre projet vient de terminer. Cliquez sur <span class="btn btn-default btn-xs">Afficher 
-                    les projets terminés</span>. Vous pouvez éditeur sa date de fin pour le prolonger.</li>
+                    les projets terminés</span>. Vous pouvez éditer sa date de fin pour le prolonger.</li>
                     <li>Vous avez archivé votre projet. Cliquez sur <span class="btn btn-default btn-xs">Afficher les
                     projets archivés</span> puis sur
                     <span class="btn btn-default btn-xs">Restaurer</span></li>
@@ -234,20 +234,20 @@ module.exports = {
         },
         {
             prefixes: ['main.projects'],
-            question: `Combien de temps mon projet va-t'il resté stocké sur Monitool?`,
+            question: `Combien de temps mon projet va-t-il rester stocké sur Monitool?`,
             answer: /* html */ `
                 Pendant toute la durée de vie de l'outil: les coûts de stockage des projets sont faibles par rapport
                 aux coûts de développement et d'hébergement de la plateforme.<br/>
                 Il ne nous est donc pas nécessaire de supprimer les anciens projets pour « faire de la place ».<br/>
                 <br/>
-                Si votre ONG dispose de règles au sujet de l'archivage électronique pour les projet terminés, vous pouvez
+                Si votre ONG dispose de règles au sujet de l'archivage électronique pour les projets terminés, vous pouvez
                 télécharger toutes les données saisies par projet depuis la page "Rapport Général"
             `,
         },
 
         {
             prefixes: ['main.invitations'],
-            question: `Je n'ai pas reçu l'invitation que j'attend`,
+            question: `Je n'ai pas reçu l'invitation que j'attends`,
             answer: /* html */ `
                 Pour vous inviter à participer à un projet, son propriétaire utilise votre adresse email.<br/>
                 Assurez-vous que vous vous êtes connecté avec la même adresse email que celle qui a été utilisée
@@ -268,7 +268,7 @@ module.exports = {
             prefixes: ['project.config'],
             question: `Comment choisir des noms adaptés pour les lieux de collecte, sources de données, variables et indicateurs`,
             answer: /* html */ `Utilisez des noms courts pour nommer les différents composants de votre projet.<br/>
-            En évitant les acronymes vous améliorez la lisibilité de vos graphiques et tableaux et permettez une meilleur
+            En évitant les acronymes vous améliorez la lisibilité de vos graphiques et tableaux et permettez une meilleure
             compréhension de votre projet par tous les acteurs concernés.`,
         },
         {
@@ -305,15 +305,15 @@ module.exports = {
         {
             prefixes: ['project.config.collection_form_list'],
             question: `
-                Que se passe-t'il quand je déplace des variables entre des sources de données qui 
-                n'ont pas les même périodicités ou lieux de collecte?
+                Que se passe-t-il quand je déplace des variables entre des sources de données qui
+                n'ont pas les mêmes périodicités ou lieux de collecte?
             `,
             answer: /* html */ `
-                Les données déjà saisies vont êtres déplacées et aggrégées ou interpolées pour s'adapter à la nouvelle périodicité.<br/>
+                Les données déjà saisies vont être déplacées et agrégées ou interpolées pour s'adapter à la nouvelle périodicité.<br/>
                 Si les lieux de collectes ne sont pas les mêmes entre les deux sources de données
                 <ul>
                     <li>Les données qui ont été saisies sur les lieux supplémentaires deviendront inaccessibles.</li>
-                    <li>Les saisisseurs seront invités à saisir retro-activement les données manquante.</li>
+                    <li>Les saisisseurs seront invités à saisir rétroactivement les données manquantes.</li>
                 </ul>
             `,
         },
@@ -321,18 +321,18 @@ module.exports = {
             prefixes: ['project.config.collection_form_edition'],
             question: `Mes équipes passent trop de temps à saisir des données, comment réduire?`,
             answer: /* html */ `
-                Réduisez la quantitée de données à collecter!<br/>
+                Réduisez la quantité de données à collecter!<br/>
                 Par exemple, vous pouvez désactiver des variables ou des désagrégations que vous n'analysez pas,
                 ou bien réduire la périodicité de la saisie.
             `,
         },
         {
             prefixes: ['project.config.collection_form_edition'],
-            question: `Je ne comprend pas les deux questions sur "Comment grouper les saisies"`,
+            question: `Je ne comprends pas les deux questions sur "Comment grouper les saisies"`,
             answer: /* html */ `
                 Monitool vous affiche des rapports selon l'échelle de temps de votre choix (semaine, mois, trimestre...) et ne vous demande
                 pas de saisir vos données autant de fois qu'il y a d'échelles de temps.<br/>
-                Pour cela, il est nécessaire de savoir comment aggréger les données qui sont saisies dans l'outil, et ces règles dependent
+                Pour cela, il est nécessaire de savoir comment agréger les données qui sont saisies dans l'outil, et ces règles dépendent
                 de la nature des données que vous saisissez.<br/>
                 <br/>
 
@@ -344,14 +344,14 @@ module.exports = {
                     </tr>
                     <tr>
                         <td>Nombre de consultations médicales</td>
-                        <td>Si 10 consultations sont réalisés par jour, cela fait 70 consulations par semaine, donc "Somme"</td>
-                        <td>10 consultations à Paris et 10 consultations à Lilles font 20 consultations, donc "Somme" également</td>
+                        <td>Si 10 consultations sont réalisées par jour, cela fait 70 consultations par semaine, donc "Somme"</td>
+                        <td>10 consultations à Paris et 10 consultations à Lille font 20 consultations, donc "Somme" également</td>
                     </tr>
                     <tr>
                         <td>Nombre de structures soutenues</td>
                         <td>10 structures étaient soutenues en janvier, et 15 en février et 20 en mars, la valeur à garder 
                         pour le trimestre est 15, donc "Moyenne"</td>
-                        <td>10 structures étaient soutenues à Paris, et 10 à Lilles, cela fait 20 structures, donc "Somme"</td>
+                        <td>10 structures étaient soutenues à Paris, et 10 à Lille, cela fait 20 structures, donc "Somme"</td>
                     </tr>                    
                 </table>
             `,
@@ -382,7 +382,7 @@ module.exports = {
             question: `Je veux arrêter de saisir une variable mais j'ai déjà réalisé des saisies.`,
             answer: /* html */ `
                 Vous pouvez désactiver des variables à tout moment sans perte de données.<br/>
-                Les données rentrées précedement seront toujours accessibles dans vos rapports, mais toutes les nouvelles
+                Les données rentrées précédemment seront toujours accessibles dans vos rapports, mais toutes les nouvelles
                 saisies seront alors marquées comme "incomplètes" dans le tableau de bord du projet, sans autres conséquences.<br/><br/>
 
                 Lorsque vous n'aurez plus usage de cette variable, vous pourrez alors la supprimer.
@@ -422,7 +422,7 @@ module.exports = {
             prefixes: ['project.config.collection_form_edition'],
             question: `Je veux supprimer une désagrégation mais j'ai déjà réalisé des saisies`,
             answer: /* html */ `
-                Toutes les données qui ont étés saisies jusqu'à ce jour vont être aggrégées, et la désagrégation va disparaitre rétroactivement
+                Toutes les données qui ont été saisies jusqu'à ce jour vont être agrégées, et la désagrégation va disparaître rétroactivement
                 des rapports.<br/>
                 Vous ne pourrez plus voir cette désagrégation dans les rapports, même sur les données saisies avant la modification.<br/>
                 Une alternative consiste à désactiver cette désagrégation.
@@ -430,8 +430,8 @@ module.exports = {
         },
         {
             prefixes: ['project.config.history'],
-            question: `Certaines modifications à la structure du projet sont réalisées par un utilisateur qui ne devrait pas avoir y avoir accès`,
-            answer: /* html */ `Vous pouvez gérer les droits des differents intervenants au projet dans la section "<i class="fa fa-share-alt"> Partage"`,
+            question: `Certaines modifications à la structure du projet sont réalisées par un utilisateur qui ne devrait pas y avoir accès`,
+            answer: /* html */ `Vous pouvez gérer les droits des différents intervenants au projet dans la section "<i class="fa fa-share-alt"> Partage"`,
         },
         {
             prefixes: ['project.config.history'],
@@ -479,23 +479,23 @@ module.exports = {
             question: `Quel est l'usage des cadres logiques en PDF?`,
             answer: /* html */ `
                 Lorsque vous communiquez sur votre projet, il est souvent plus pratique d'envoyer votre
-                cadre logique par email, plutôt que de demander à un bailleur ou un partenaire se se connecter
+                cadre logique par email, plutôt que de demander à un bailleur ou un partenaire de se connecter
                 à une plateforme en ligne pour y avoir accès.<br/>
 
                 Pouvoir les télécharger vous évitera ainsi un double travail: concevez votre cadre logique directement
-                sur l'outil, et disposez d'une version toujours à jour prette à être transmise.
+                sur l'outil, et disposez d'une version toujours à jour prête à être transmise.
             `,
         },
         {
             prefixes: ['project.usage.downloads'],
             question: `Quel est l'usage des fiches de saisie en format PDF et Excel?`,
             answer: /* html */ `
-                Dans de nombreux contextes, la mise en place d'outil de collecte de donnée électroniques 
+                Dans de nombreux contextes, la mise en place d'outils de collecte de données électroniques
                 demande du temps et des ressources en formation.
                 <ul>
                     <li>
                         La version PDF des fiches de saisies est facilement imprimable, ne demande aucune formation
-                        pour être utilisée, et peut être opérationelle dès le premier jour de votre projet.
+                        pour être utilisée, et peut être opérationnelle dès le premier jour de votre projet.
                     </li>
                     <li>
                         La version Excel est une alternative pour les lieux de collecte où l'accès à l'informatique est
@@ -510,7 +510,7 @@ module.exports = {
             prefixes: ['project.usage.downloads'],
             question: `Sur mes fiches de saisie, les tableaux sont trop larges et dépassent de la page`,
             answer: /* html */ `
-                Deux possibilitées s'offrent à vous:
+                Deux possibilités s'offrent à vous:
                 <ul>
                     <li>
                         Une version "paysage" de la même fiche de saisie est disponible en cliquant sur 
@@ -580,7 +580,7 @@ module.exports = {
             answer: /* html */ `
                 Elle est de 16 mega-octets par fichier.<br/>
                 Cependant, il est inutile de téléverser des photos dont la taille dépasse 2 mega-octets:
-                des images à trop haute résolution ralentissent le traitement, et n'améliore pas sa qualité. 
+                des images à trop haute résolution ralentissent le traitement, et n'améliorent pas sa qualité.
             `,
         },
         {
@@ -609,7 +609,7 @@ module.exports = {
                 Par contre, il n'est pas nécessaire de:
                 <ul>
                     <li>Être à la verticale au dessus du formulaire pour prendre la photo.</li>
-                    <li>Que les bords du formulaires corresponde au bord de la photo</li>
+                    <li>Que les bords du formulaire correspondent au bord de la photo</li>
                 </ul>
             `,
         },
@@ -625,16 +625,16 @@ module.exports = {
             prefixes: ['project.usage.edit', 'project.usage.data_entry'],
             question: `Comment passer rapidement d'une case à l'autre?`,
             answer: /* html */ `
-                Lors de la saisie de données, la touch Tab de votre clavier vous permet de naviguer entre les cases.<br/>
+                Lors de la saisie de données, la touche Tab de votre clavier vous permet de naviguer entre les cases.<br/>
                 Pour revenir à la case précédente, utilisez Shift + Tab
             `,
         },
         {
             prefixes: ['project.usage.edit', 'project.usage.data_entry'],
-            question: `Je saisie à partir de fiches papier remontées par plusieurs intervenants par lieu de collecte. Comment saisir plus rapidement?`,
+            question: `Je saisis à partir de fiches papier remontées par plusieurs intervenants par lieu de collecte. Comment saisir plus rapidement?`,
             answer: /* html */ `
                 Si vous disposez de plusieurs formulaires papier à saisir par lieu (par exemple, un par travailleur social),
-                et que désirez les additioner, vous pouvez rentrer des sommes dans les cases de saisies: "1+2+3".<br/>
+                et que désirez les additionner, vous pouvez rentrer des sommes dans les cases de saisie: "1+2+3".<br/>
             `,
         },
         {
@@ -649,7 +649,7 @@ module.exports = {
             question: `À quoi sert le bouton "Remplir avec les données de la période précédente"`,
             answer: /* html */ `
                 À gagner du temps dans certains cas particuliers!<br/>
-                Si votre projet suit des indicateur qui nécessitent des indicateurs qui varient peu dans le temps (nombre de structure soutenues,
+                Si votre projet suit des indicateurs qui varient peu dans le temps (nombre de structures soutenues,
                 population de la zone ciblée, ...), il est souvent plus facile de copier les données de la saisie précédente et de corriger
                 les différences, que de réaliser la saisie à partir de zéro.
             `,
@@ -665,10 +665,10 @@ module.exports = {
         },
         {
             prefixes: ['project.usage.edit', 'project.usage.data_entry'],
-            question: `Que se passe-t'il si je laisse certaines cases en blanc?`,
+            question: `Que se passe-t-il si je laisse certaines cases en blanc?`,
             answer: /* html */ `
                 Attention!<br/>
-                Une case laissée blanche n'est pas équivalente à une case qui contient un zéro. Les données non saisies apparaitront comme telles
+                Une case laissée blanche n'est pas équivalente à une case qui contient un zéro. Les données non saisies apparaîtront comme telles
                 dans les rapports.
             `,
         },
@@ -697,7 +697,7 @@ module.exports = {
             prefixes: ['project.usage.general'],
             question: `Comment désagréger mes données par tranche d'age, sexe, pathologie, contenu de formation, ...?`,
             answer: /* html */ `
-                    Si vous avez utilisé des désagrégations lors de la collecte de vos données celles-ci apparaitront dans le
+                    Si vous avez utilisé des désagrégations lors de la collecte de vos données celles-ci apparaîtront dans le
                     menu qui est accessible sur chaque ligne en cliquant sur le symbole <i class="fa fa-plus"></i>.<br/>
                     Pour les indicateurs calculés (cadres logiques, et indicateurs supplémentaires), il n'est possible de désagréger
                     les resultats que par lieu de collecte et par unité de temps.`,
@@ -711,13 +711,13 @@ module.exports = {
             prefixes: ['project.usage.general', 'project.usage.olap'],
             question: `Que signifie le symbole <i class="fa fa fa-exclamation"></i> qui s'affiche à la place de mes données?`,
             answer: /* html */ `
-                Ce symbole signifie qu'une division par zéro à eu lieu!
+                Ce symbole signifie qu'une division par zéro a eu lieu!
             `,
         },
         {
             prefixes: ['project.usage.general', 'project.usage.olap'],
             question: `Pourquoi certaines données sont précédées par le symbole ≈?`,
-            answer: /* html */ `Vous consultez ces données à un niveau d'aggrégation qui est inférieur à celui auquel vous les avez collecté!<br/>
+            answer: /* html */ `Vous consultez ces données à un niveau d'agrégation qui est inférieur à celui auquel vous les avez collecté!<br/>
                 Par exemple, vous avez réalisé la collecte trimestriellement, mais consultez ces données sur un tableau qui les affiche
                 mensuellement.<br/><br/>
                 Dans ce cas, les données sont "interpolés" afin de vous permettre d'avoir des ordres de grandeurs, et de pouvoir
@@ -737,7 +737,7 @@ module.exports = {
             answer: /* html */ `
                 Les données affichées en <i>italique</i> n'ont été que partiellement saisies. Le plus souvent, cela signifie que
                 seules certains des lieux de collectes attendus ont été saisis.
-                Le cas peut également se produire si vous consultez une version aggrégée (ex: par trimestre) de données collectés
+                Le cas peut également se produire si vous consultez une version agrégée (ex: par trimestre) de données collectées
                 à une periodicité plus courte (ex: par mois) et que tous les mois du trimestre considéré n'ont pas été saisis.<br/>
                 En désagrégant la ligne avec le bouton <i class="fa fa-plus"></i> vous pourrez trouver facilement les saisies manquantes.`,
         },

--- a/frontend/src/translation/fr/translations.js
+++ b/frontend/src/translation/fr/translations.js
@@ -9,7 +9,7 @@ export default {
     refuse_invitation: 'Refuser',
     uninvite: 'Retirer de mes projets',
     no_invitations: "Vous n'avez aucune invitation en attente!",
-    no_invitations_back: 'Retournez à la liste de vos projet',
+    no_invitations_back: 'Retournez à la liste de vos projets',
 
     configure: 'Configuration',
     back: 'Retour',
@@ -61,7 +61,7 @@ export default {
     logout: 'Déconnecter',
 
     sure_to_leave:
-      'Vous avez realisé des changements. Êtes-vous sûr de vouloir quitter sans sauvegarder?',
+      'Vous avez réalisé des changements. Êtes-vous sûr de vouloir quitter sans sauvegarder?',
   },
   menu: {
     language: 'Langue',
@@ -72,12 +72,12 @@ export default {
   welcome: {
     i_got_it: "J'ai compris! Commençons!",
     text: /* html */ `
-            <legend>Bienvenu!</legend>
+            <legend>Bienvenue !</legend>
             <p>C'est votre première visite sur Monitool.</p>
             <p>
                 Afin de vous aider à appréhender l'outil nous avons créé un premier projet dans votre
                 espace!<br />
-                Il utilise la majorité des fonctionalitées de l'outil, et pourra vous servir de référence.
+                Il utilise la majorité des fonctionnalités de l'outil, et pourra vous servir de référence.
             </p>
             <ul>
                 <li>
@@ -103,7 +103,7 @@ export default {
                 Pour y accéder:
             </p>
             <ul style="margin-bottom: 20px">
-                <li>Déplacez le pointeur de votre souris sur la barre latéral à droite de votre écran.</li>
+                <li>Déplacez le pointeur de votre souris sur la barre latérale à droite de votre écran.</li>
                 <li>Attendez un court instant.</li>
             </ul>
         `,
@@ -114,8 +114,8 @@ export default {
     add_invitation: 'Inviter une personne',
     email: 'Email',
     help_email: "Quel est l'email de la personne que vous désirez inviter?",
-    help_sites: "Sur quels lieux de collecte cette personne pourra-t'elle saisir?",
-    help_datasources: " Sur quels sources de données cette personne pourra-t'il saisir?",
+    help_sites: 'Sur quels lieux de collecte cette personne pourra-t-elle saisir?',
+    help_datasources: 'Sur quelles sources de données cette personne pourra-t-elle saisir?',
     accepted: 'Acceptée',
     contact: 'Contact',
     data_entry_perms: 'Permissions saisie',
@@ -127,7 +127,7 @@ export default {
     uploads: 'Papier & Excel',
 
     drop_file_here:
-      'Déposez ici vos fiches de saisies remplies ou <label for="file-input">choisissez des fichier</label>',
+      'Déposez ici vos fiches de saisies remplies ou <label for="file-input">choisissez des fichiers</label>',
     drop_file_here_formats:
       'Formats supportés: Photo, scan, fax (pdf, jpg, png, tiff), excel (xlsx) ou archive (zip).',
     waiting_dataentry: 'En attente de saisie',
@@ -243,9 +243,9 @@ export default {
       forms_elements_active_replace:
         "{{after ? 'Active' : 'Désactive'}} la saisie de la variable <code>{{variable.name}}</code>",
       forms_elements_geoAgg_replace:
-        "Change la règle d'aggrégation (lieux) de <code>{{variable.name}}</code> de <code>{{before}}</code> vers <code>{{after}}</code>",
+        "Change la règle d'agrégation (lieux) de <code>{{variable.name}}</code> de <code>{{before}}</code> vers <code>{{after}}</code>",
       forms_elements_timeAgg_replace:
-        "Change la règle d'aggrégation (temps) de <code>{{variable.name}}</code> de <code>{{before}}</code> vers <code>{{after}}</code>",
+        "Change la règle d'agrégation (temps) de <code>{{variable.name}}</code> de <code>{{before}}</code> vers <code>{{after}}</code>",
       forms_elements_distribution_replace:
         'Change la présentation de la saisie de la variable <code>{{variable.name}}</code>',
 
@@ -260,7 +260,7 @@ export default {
       forms_elements_partitions_active_replace:
         "{{after ? 'Active' : 'Désactive'}} la saisie de la désagrégation <code>{{partition.name}}</code> de la variable <code>{{variable.name}}</code>",
       forms_elements_partitions_aggregation_replace:
-        "Change la règle d'aggrégation de <code>{{before}}</code> vers <code>{{after}}</code> pour la variable <code>{{variable.name}}</code>",
+        "Change la règle d'agrégation de <code>{{before}}</code> vers <code>{{after}}</code> pour la variable <code>{{variable.name}}</code>",
 
       forms_elements_partitions_elements_add:
         "Ajoute l'élément <code>{{item.name}}</code> dans la désagrégation <code>{{partition.name}}</code> de la variable <code>{{variable.name}}</code>",
@@ -380,13 +380,13 @@ export default {
     form_persisted: 'Vos données sont sauvegardées.',
     form_changed: "Vous avez réalisé des changements. N'oubliez pas de cliquer sur sauvegarder.",
 
-    show_more_inputs: 'Voir les dates précedentes',
+    show_more_inputs: 'Voir les dates précédentes',
     all_elements: 'Tout',
     no_extra_indicators: "Aucun indicateur annexé n'a été créé.",
     no_data_source_yet: "Aucune source de données n'a été créée.",
     no_data_source:
       '<span style="font-style: italic">Aucune source de données n\'est prête à la saisie</span>',
-    general_info: 'Information génerales',
+    general_info: 'Informations générales',
     indicator_computation_missing: 'Calcul absent',
     which_variable: 'De quelle variable provient cette information?',
     which_partitions: 'Quelles désagrégations sont concernées?',
@@ -394,10 +394,10 @@ export default {
 
     computations: {
       unavailable: "Il n'est pas possible de calculer cet indicateur",
-      copy: 'Copier une valeur (depuis une sources de données)',
+      copy: 'Copier une valeur (depuis une source de données)',
       percentage: 'Pourcentage (depuis les sources de données)',
       permille: 'Pour mille (depuis les sources de données)',
-      formula: 'Formule personalisée (depuis les sources de données)',
+      formula: 'Formule personnalisée (depuis les sources de données)',
     },
 
     formula: {
@@ -413,10 +413,10 @@ export default {
     partition_help_name:
       'Ce nom apparaîtra dans divers rapports. Il nomme la désagrégation que vous voulez créer sur votre donnée',
     partition_help_elements:
-      'Les éléments de la désagrégation doivent être mutuellement exclusifs, et il doit être possible de trouver la valeur totale en les aggrégant.',
+      'Les éléments de la désagrégation doivent être mutuellement exclusifs, et il doit être possible de trouver la valeur totale en les agrégeant.',
     partition_help_aggregation:
       'Comment trouver la valeur totale en agrégeant les éléments décrits?',
-    partition_help_groups: 'Les groupes permettent de faire des aggrégations intermédiaires',
+    partition_help_groups: 'Les groupes permettent de faire des agrégations intermédiaires',
     logical_frame: 'Cadre logique',
 
     no_data: 'Les données ne sont pas disponibles',
@@ -499,8 +499,8 @@ export default {
     aggregation: {
       sum: 'Faire une somme',
       average: 'Faire une moyenne',
-      highest: 'Prendre la plus grande valeure',
-      lowest: 'Prendre la plus petite valeure',
+      highest: 'Prendre la plus grande valeur',
+      lowest: 'Prendre la plus petite valeur',
       last: 'Prendre la dernière valeur',
       none: "Il n'est pas possible de faire ce calcul",
     },
@@ -538,10 +538,10 @@ export default {
     periodicities: {
       day: 'Tous les jours',
       month_week_sat: 'Toutes les semaines (samedi à vendredi / coupées par mois)',
-      month_week_sun: 'Toutes les semaines (dimanche à lundi / coupées par mois)',
+      month_week_sun: 'Toutes les semaines (dimanche à samedi / coupées par mois)',
       month_week_mon: 'Toutes les semaines (lundi à dimanche / coupées par mois)',
       week_sat: 'Toutes les semaines (samedi à vendredi)',
-      week_sun: 'Toutes les semaines (dimanche à lundi)',
+      week_sun: 'Toutes les semaines (dimanche à samedi)',
       week_mon: 'Toutes les semaines (lundi à dimanche)',
       month: 'Tous les mois',
       quarter: 'Tous les trimestres',
@@ -617,20 +617,20 @@ export default {
     add_purpose: 'Ajouter un objectif spécifique',
 
     basics_help_country:
-      "Dans quel pays le projet se déroule-t'il? S'il s'agit d'un projet régional, entrez le nom de la région.",
+      "Dans quel pays le projet se déroule-t-il? S'il s'agit d'un projet régional, entrez le nom de la région.",
     basics_help_name:
-      "Le nom permet de retrouver le projet dans Monitool. Choisissez un nom suffisament informatif, ou copiez l'objectif général du projet.",
+      "Le nom permet de retrouver le projet dans Monitool. Choisissez un nom suffisamment informatif, ou copiez l'objectif général du projet.",
     basics_help_begin:
       'La date de début représente le moment où le projet commence à collecter des données (généralement, le début des activités)',
     basics_help_end:
-      "La date de fin représente le moment où le projet finale sa collecte de données. Si cette date n'est pas connu à l'avance, rentrer une date lointaine dans le futur.",
+      "La date de fin représente le moment où le projet finalise sa collecte de données. Si cette date n'est pas connue à l'avance, rentrez une date lointaine dans le futur.",
 
     collection_edit_help_name:
       'Comment s\'apelle la source de laquelle vous voulez extraire des données? Par exemple: "Dossier patient informatisé", "Registre des centre de santé", "Rapport du système national d\'information sanitaire", ...',
     collection_edit_help_sites:
-      'Parmi les structures identifiées dans "Lieux de collecte", lesquelles font remonter cette source de donnée?',
+      'Parmi les structures identifiées dans "Lieux de collecte", lesquelles font remonter cette source de données?',
     collection_edit_help_periodicity:
-      'À quelle fréquence ces données remontent-elles? Attention, cette fréquence est complétement decorrelée de la fréquence à laquelle le projet doit fournir du reporting.',
+      'À quelle fréquence ces données remontent-elles? Attention, cette fréquence est complètement décorrélée de la fréquence à laquelle le projet doit fournir du reporting.',
 
     collection_edit_help_varname:
       'Nommez la variable que vous voulez extraire de/du <code>{{name}}</code>. Par exemple "Nombre de diagnostics effectués".',
@@ -639,7 +639,7 @@ export default {
     collection_edit_help_timeagg:
       'Dans un projet qui collecte mensuellement, si <code>{{name}}</code> vaut 10 en janvier, et 20 en février et 30 en mars que vaut-il pour le premier trimestre?',
     collection_edit_help_partition:
-      "Veut-t'on être capable de différencier <code>{{name}}</code> par age, sexe, prise en charge, motif de consultation, pathologie, tranche horaire, reférencement effectif, ...?<br/>Ne désagrégez pas ici par zone géographique ou site d'intervention: vos lieux de collecte ont déjà été renseignés dans la page prévu à cet effet.",
+      "Veut-on être capable de différencier <code>{{name}}</code> par âge, sexe, prise en charge, motif de consultation, pathologie, tranche horaire, référencement effectif, ...?<br/>Ne désagrégez pas ici par zone géographique ou site d'intervention: vos lieux de collecte ont déjà été renseignés dans la page prévue à cet effet.",
     collection_edit_help_distribution:
       'Si vous desirez imprimer des formulaires en A4, préférez placer les intitulés sur la gauche des tableaux, afin de limiter leur largeur.',
     collection_edit_help_order:
@@ -650,7 +650,7 @@ export default {
 
     titles: 'Intitulés',
     data: 'Données',
-    general_informations: 'Informations génerales',
+    general_informations: 'Informations générales',
     fill_from_last: 'La saisie précédente',
     fill_from_upload: 'Le fichier téléchargé',
     fill_with_zeros: 'Zéro',
@@ -689,7 +689,7 @@ export default {
       "Rentrez ici les indicateurs permettant de mesurer l'avancement de l'activité",
 
     form_is_not_associated_with_site:
-      "Cette source de données n'est associé à aucun lieu de collecte.",
+      "Cette source de données n'est associée à aucun lieu de collecte.",
   },
 
   form: {

--- a/frontend/static/index.html
+++ b/frontend/static/index.html
@@ -162,7 +162,7 @@
                   <li>Once you start measuring them, which figures do you expect to find?</li>
                   <li>
                     How much of your operative staff time are you willing to allocate to data
-                    collection? Who is reponsible for what?
+                    collection? Who is responsible for what?
                   </li>
                   <li>
                     Will the effects of your project be able to change those indicators in a
@@ -240,7 +240,7 @@
                     <p>
                       Monitool projects are extremely tolerant to change. All user actions are
                       dated, attributed to someone and can be reverted in one click. Already
-                      collected data is updated in simple, predictible and revertible ways.<br />
+                      collected data is updated in simple, predictable and reversible ways.<br />
                       No loss of data is possible.
                     </p>
                   </div>
@@ -336,7 +336,7 @@
               <i class="fa fa-book fa-lg"></i>
               <h4>In-app documentation</h4>
               <p>
-                On each page a help panel is available, and contains each questions which was ever
+                On each page a help panel is available, and contains every question which was ever
                 asked to us.
               </p>
             </div>
@@ -358,7 +358,7 @@
               <i class="fa fa-graduation-cap fa-lg"></i>
               <h4>Learn by example</h4>
               <p>
-                Samples projects which use all features of the tool are provided and will be waiting
+                Sample projects which use all features of the tool are provided and will be waiting
                 for you when you log in.
               </p>
             </div>
@@ -411,7 +411,7 @@
         </div>
         <div class="row">
           <div class="col-md-6 col-sm-6">
-            <legend style="margin-top: 20px">Methodolody</legend>
+            <legend style="margin-top: 20px">Methodology</legend>
             <p>
               Monitool was built from an internal tool open-sourced by
               <a href="https://www.medecinsdumonde.org" target="_blank">Médecins du Monde France</a


### PR DESCRIPTION
## Summary
This PR corrects numerous spelling, grammar, and punctuation errors across Spanish, French, and English translation files, as well as HTML templates. The changes improve the quality and professionalism of user-facing text throughout the application.

## Key Changes

### Spanish Translations (`frontend/src/translation/es/translations.js`)
- Fixed accent marks: "Si" → "Sí", "Deactivar" → "Desactivar", "Acceptar" → "Aceptar"
- Corrected conjunctions: "e archivar" → "y archivar"
- Fixed capitalization: "Esta seguro" → "Está seguro"
- Corrected verb forms: "Empezemos" → "Empecemos", "Solte" → "Suelte"
- Fixed technical terms: "marco logico" → "marco lógico", "Proprietario" → "Propietario"
- Corrected multiple instances of "objectivo" → "objetivo" and "hypotesis" → "hipótesis"
- Fixed typos: "groupo" → "grupo", "Reemplaca" → "Reemplaza", "Remplaca" → "Reemplaza"
- Corrected various verb conjugations and spelling errors throughout

### French Translations (`frontend/src/translation/fr/translations.js` and `frontend/src/translation/fr/help.js`)
- Fixed spelling: "même" → "mêmes", "individuellements" → "individuellement"
- Corrected verb forms: "utilisé" → "utilisés", "misent" → "mises", "permette" → "permettent"
- Fixed accents and diacritics: "oeuvre" → "œuvre", "accèder" → "accéder"
- Corrected grammar: "projet" → "projets", "clickez" → "cliquez"
- Fixed technical terminology: "fonctionalité" → "fonctionnalité", "opérationel" → "opérationnel"
- Corrected various French grammar and spelling issues

### English Translations (`frontend/src/translation/en/translations.js` and `frontend/src/translation/en/help.js`)
- Fixed typos: "criterias" → "criteria", "framwork" → "framework"
- Corrected verb forms: "did not made" → "have not made", "comes from" → "come"
- Fixed redundancy: "start date of the project" → "start date"
- Corrected prepositions: "de" → "from", "vers" → "to"
- Fixed spelling: "Deletee" → "Delete", "Disagregation" → "Disaggregation"

### HTML Templates
- Spanish (`home-es.html`): Fixed gender agreement "utilizado" → "utilizada"
- French (`home-fr.html`): Fixed verb form "utilisé" → "utilisée", corrected "oeuvre" → "œuvre"
- English (`home-en.html`): Fixed "founded" → "funded"
- Static HTML (`index.html`): Fixed "reponsible" → "responsible", "predictible" → "predictable", "revertible" → "reversible"

## Implementation Details
- All changes are purely textual corrections with no functional code modifications
- Corrections maintain consistency with standard spelling conventions in each language
- Grammar and punctuation improvements enhance readability and professionalism
- No changes to application logic, structure, or behavior

https://claude.ai/code/session_01Qu18vEtNHGhLF9tQaLDdpy