### PR TITLE
chore: add Dockerfile and Caddyfile for self-hosting

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.git
+.gitignore

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -1,0 +1,6 @@
+:80 {
+    root * /srv
+    encode gzip zstd
+    try_files {path} /index.html
+    file_server
+}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:16.20.2-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npx webpack --config webpack.config.prod.js
+
+FROM caddy:2-alpine
+COPY --from=build /app/dist /srv
+COPY Caddyfile /etc/caddy/Caddyfile


### PR DESCRIPTION
## Summary
- Adds a multi-stage `Dockerfile` in `frontend/` that builds with `node:16.20.2-alpine` (matches `package.json` engines) and serves the webpack output with `caddy:2-alpine`.
- Adds a `Caddyfile` with gzip/zstd and SPA fallback (`try_files {path} /index.html`).
- Adds a `.dockerignore` excluding `node_modules`, `dist`, `.git`.

Enables self-hosting the frontend as a container.

## Test plan
- [x] `docker build -t monitool-frontend:test .` succeeds
- [x] Container runs and serves `/` (200, index.html)
- [x] SPA fallback works (unknown paths → 200 index.html)
- [x] Static assets served with correct Content-Type (JS bundles, CSS, fonts, images, `.well-known/`)